### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Node.js implementation of a Git repository browser using the Model Context Protocol (MCP).
 
+<a href="https://glama.ai/mcp/servers/zmmq29sb91">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/zmmq29sb91/badge" alt="Git Repo Browser MCP server" />
+</a>
+
 ## Configuration
 
 Add this to your MCP settings configuration file:


### PR DESCRIPTION
This PR adds a badge for the [MCP Git Repo Browser](https://glama.ai/mcp/servers/zmmq29sb91) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/zmmq29sb91">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/zmmq29sb91/badge" alt="Git Repo Browser MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.